### PR TITLE
fix: scan JS files for production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ const client = new discord.Client({
 const features: FeatureFile[] = [];
 const featureFiles = fs
   .readdirSync(path.resolve(__dirname, './features'))
-  .filter((file) => file.endsWith('.ts'));
+  // Look for files as TS (dev) or JS (built files)
+  .filter((file) => file.endsWith('.ts') || file.endsWith('.js'));
 
 for (const featureFile of featureFiles) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
After the build the files have the `.js` extension so we need to look for those too, otherwise no features would be enabled in production