### PR TITLE
fix: require node 16.6 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "prettier": "^2.4.1",
     "ts-node-dev": "^1.1.8",
     "typescript": "^4.4.4"
+  },
+  "engines": {
+    "node": ">=16.6"
   }
 }


### PR DESCRIPTION
`discord.js` uses features that requires Node.js v16.6 or higher, this setting in `package.json` will make Heroku pick a higher version so the bot doesn't crash at startup